### PR TITLE
Update template.tex

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -32,7 +32,7 @@
 %%
 \usepackage{graphicx,latexsym}
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{fullpage}
+%\usepackage{fullpage}
 \usepackage{longtable,booktabs,setspace}
 \usepackage{chemarr} %% Useful for one reaction arrow, useless if you're not a chem major
 \usepackage[hyphens]{url}


### PR DESCRIPTION
It looks like the `\headheight is too small` warning comes from your addition of `\usepackage{fullpage}` in the `template.tex` file. Removing that gets the warning to go away and hopefully clears up [this issue](https://github.com/ismayc/thesisdown/issues/102). [Here's some more info](https://tex.stackexchange.com/questions/267689/problem-with-fancy-header) on what `fullpage` does and why it can produce warnings like this.